### PR TITLE
Gloss Locations

### DIFF
--- a/align-glosses.html
+++ b/align-glosses.html
@@ -20,12 +20,10 @@
         <auth-button class="container">
             <button is="auth-button">login</button>
         </auth-button>
-
     </gm-header>
+
     <h3 id="glossTitle" class="deer-view send-id" deer-template="label">Gloss Alignment</h3>
     <input is="auth-creator" type="hidden" deer-key="creator" />
-
-    <deer-view deer-id="" class="send-id" deer-template="pageLinks"></deer-view>
 
     <div class="row">
         <deer-view id="glossNumBtns" class="col-6" deer-collection="Glossing-Matthew-Named-Glosses"
@@ -36,8 +34,9 @@
 
     <deer-view id="previewTranscription" deer-template="folioTranscription"></deer-view>
 
-    <pre
-        class="card bg-light is-hidden"><deer-view id="frPreview" deer-template="entity">current state</deer-view></pre>
+    <pre class="card bg-light is-hidden">
+        <deer-view id="frPreview" deer-template="entity">current state</deer-view>
+    </pre>
 
     <gm-footer>
         <a href="./index.html">🏠</a>

--- a/layout.html
+++ b/layout.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>Glossing Matthew</title>
+    <title>Gloss Locations</title>
     <link rel="stylesheet" href="css/gloss.css">
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
     <script src="/js/auth.js" type="module"></script>
@@ -24,7 +24,6 @@
     <h3 id="glossTitle" class="deer-view send-id" deer-id="" deer-template="label">Layout Editor</h3>
     <input is="auth-creator" type="hidden" deer-key="creator" />
 
-    <deer-view deer-id="" class="send-id" deer-template="pageLinks"></deer-view>
     <div class="row">
         <deer-view id="folioLayout" deer-id="" class="send-id col-6" deer-template="lines"></deer-view>
         <deer-view class="col-6 send-id" deer-id="" id="zoomy" deer-template="osd"></deer-view>
@@ -32,8 +31,9 @@
 
     <deer-view id="previewTranscription" deer-template="folioTranscription"></deer-view>
 
-    <pre
-        class="card bg-light is-hidden"><deer-view id="frPreview" deer-template="entity">current state</deer-view></pre>
+    <pre class="card bg-light is-hidden">
+        <deer-view id="frPreview" deer-template="entity">current state</deer-view>
+    </pre>
 
     <gm-footer>
         <a href="./index.html">🏠</a>

--- a/layout.html
+++ b/layout.html
@@ -25,7 +25,7 @@
     <input is="auth-creator" type="hidden" deer-key="creator" />
 
     <div class="row">
-        <deer-view id="folioLayout" deer-id="" class="send-id col-6" deer-template="lines"></deer-view>
+        <deer-view id="folioLayout" deer-id="" class="send-id col-6" deer-template="lines_new"></deer-view>
         <deer-view class="col-6 send-id" deer-id="" id="zoomy" deer-template="osd"></deer-view>
     </div>
 


### PR DESCRIPTION
Have Annotations that target lines instead of Canvases.  To do so....

Each page now has 8 Annotations for it, one for each of the following locations

1. "ulm"
2. "urm"
3. "um" 
4. "llm" 
5. "lm"
6. "lrm"
7. "ti"
8. "li"

Their current prototypes look like
```JSON
{
   "@id":"http://store.rerum.io/v1/id/6377dc531267884358927597",
   "@type":"Annotation",
   "@context":"http://www.w3.org/ns/anno.jsonld",
   "target":[
      "104721012",
      "104721013"
   ],
   "forCanvas":"http://tpentest.rerum.io/TPEN/canvas/13251387",
   "body":{
      "location":"llm"
   },
   "motivation":"classifying",
   "locationing":true
}
```

So a set of lines is targeted with a body that notes the location of those lines.

This means highlightLocations() and saveLocations() have gone through a rather dramatic change to account for this new way of Annotating locations onto lines.

I am still using a dirty `forCanvas` trick to maintain the connection of these lines to their canvas.  It makes querying for them in RERUM so much easier.